### PR TITLE
Add message_serializer to initializer

### DIFF
--- a/connect.py
+++ b/connect.py
@@ -103,7 +103,8 @@ def execute_drop_operations(client):
 try:
     client = client.Client('wss://<YOUR_ENDPOINT>.gremlin.cosmosdb.azure.com:443/','g', 
         username="/dbs/<YOUR_DATABASE>/colls/<YOUR_COLLECTION_OR_GRAPH>", 
-        password="<YOUR_PASSWORD>"
+        password="<YOUR_PASSWORD>",
+        message_serializer=serializer.GraphSONSerializersV2d0()
     )
     
     print("Welcome to Azure Cosmos DB + Gremlin on Python!")


### PR DESCRIPTION
The example doesn't work when the message_serializer is left off (Gremlin defaults this to GraphSONSerializersV3d0).

## Purpose

* Fix the sample code so it runs out of the box.

## Does this introduce a breaking change?
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
* Get the code
```
git clone https://github.com/scovetta/azure-cosmos-db-graph-python-getting-started test
cd test
git checkout patch-1
[Update connect.py with your credentials, as per README.md]
```

* Test the code
```
Run `connect.py` as indicated within the README.md file.
```

## What to Check
Verify that the following are valid:
* Does the `connect.py` script complete as expected?

## Other Information
I'm not sure whether this is a bug/missing feature in the Gremlin client or the Cosmos DB backend.