### PR TITLE
Update gremlin endpoint to use the new sub-domain for connection string

### DIFF
--- a/connect.py
+++ b/connect.py
@@ -156,7 +156,7 @@ def execute_drop_operations(client):
 
 
 try:
-    client = client.Client('wss://<YOUR_ENDPOINT>.gremlin.cosmosdb.azure.com:443/', 'g',
+    client = client.Client('wss://<YOUR_ENDPOINT>.gremlin.cosmos.azure.com:443/', 'g',
                            username="/dbs/<YOUR_DATABASE>/colls/<YOUR_COLLECTION_OR_GRAPH>",
                            password="<YOUR_PASSWORD>",
                            message_serializer=serializer.GraphSONSerializersV2d0()


### PR DESCRIPTION
Replace old-style endpoint sub-domain to be `gremlin.cosmos.azure.com` for the connection string, vs `gremlin.cosmosdb.azure.com`

## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* ...

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[ ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->